### PR TITLE
Make all internal iterator classes package private accessible

### DIFF
--- a/src/main/java/org/paukov/combinatorics/combination/multi/MultiCombinationIterator.java
+++ b/src/main/java/org/paukov/combinatorics/combination/multi/MultiCombinationIterator.java
@@ -19,33 +19,33 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  *            Type of the elements in the combinations
  * @version 2.0
  */
-public class MultiCombinationIterator<T> implements
+class MultiCombinationIterator<T> implements
 		Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Generator
 	 */
-	protected final MultiCombinationGenerator<T> _generator;
+	final MultiCombinationGenerator<T> _generator;
 
 	/**
 	 * Current combination
 	 */
-	protected ICombinatoricsVector<T> _currentCombination = null;
+	ICombinatoricsVector<T> _currentCombination = null;
 
 	/**
 	 * Index of the current combination
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Size of the original vector/set
 	 */
-	protected final int _lengthN;
+	final int _lengthN;
 
 	/**
 	 * Size of the combinations (number of elements) to generate
 	 */
-	protected final int _lengthK;
+	final int _lengthK;
 
 	/**
 	 * A helper array
@@ -63,7 +63,7 @@ public class MultiCombinationIterator<T> implements
 	 * @param generator
 	 *            Multi-combinations generator
 	 */
-	public MultiCombinationIterator(MultiCombinationGenerator<T> generator) {
+	MultiCombinationIterator(MultiCombinationGenerator<T> generator) {
 		_generator = generator;
 		_lengthN = generator.getOriginalVector().getSize();
 		_currentCombination = Factory.createVector();

--- a/src/main/java/org/paukov/combinatorics/combination/simple/SimpleCombinationIterator.java
+++ b/src/main/java/org/paukov/combinatorics/combination/simple/SimpleCombinationIterator.java
@@ -19,33 +19,33 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of the elements in the combinations
  */
-public class SimpleCombinationIterator<T> implements
+class SimpleCombinationIterator<T> implements
 		Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Generator
 	 */
-	protected final SimpleCombinationGenerator<T> _generator;
+	final SimpleCombinationGenerator<T> _generator;
 
 	/**
 	 * Current simple combination
 	 */
-	protected ICombinatoricsVector<T> _currentSimpleCombination = null;
+	ICombinatoricsVector<T> _currentSimpleCombination = null;
 
 	/**
 	 * Index of the current combination
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Size of the original vector/set
 	 */
-	protected final int _lengthN;
+	final int _lengthN;
 
 	/**
 	 * Size of the generated combination.
 	 */
-	protected final int _lengthK;
+	final int _lengthK;
 
 	/**
 	 * Helper array
@@ -63,7 +63,7 @@ public class SimpleCombinationIterator<T> implements
 	 * @param generator
 	 *            Generator of the simple combinations
 	 */
-	public SimpleCombinationIterator(SimpleCombinationGenerator<T> generator) {
+	SimpleCombinationIterator(SimpleCombinationGenerator<T> generator) {
 		_generator = generator;
 		_lengthN = generator.getOriginalVector().getSize();
 		_lengthK = generator.getCombinationLength();

--- a/src/main/java/org/paukov/combinatorics/composition/CompositionIterator.java
+++ b/src/main/java/org/paukov/combinatorics/composition/CompositionIterator.java
@@ -19,45 +19,42 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @see ICombinatoricsVector
  * @see CompositionGenerator
  */
-public class CompositionIterator implements
+class CompositionIterator implements
 		Iterator<ICombinatoricsVector<Integer>> {
 
-	/**
-	 * Generator
-	 */
-	protected final CompositionGenerator _generator;
+	final CompositionGenerator _generator;
 
 	/**
 	 * Current composition
 	 */
-	protected ICombinatoricsVector<Integer> _currentComposition = null;
+	ICombinatoricsVector<Integer> _currentComposition = null;
 
 	/**
 	 * Current index of the weak composition
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Subset generator
 	 */
-	protected final Generator<Integer> _subsetGenerator;
+	final Generator<Integer> _subsetGenerator;
 
 	/**
 	 * Subset iterator
 	 */
-	protected final Iterator<ICombinatoricsVector<Integer>> _subsetIterator;
+	final Iterator<ICombinatoricsVector<Integer>> _subsetIterator;
 
 	/**
 	 * Current subset
 	 */
-	protected ICombinatoricsVector<Integer> _currentSubset = null;
+	ICombinatoricsVector<Integer> _currentSubset = null;
 
 	/**
 	 * Constructor of the iterator
 	 * 
 	 * @param generator The Composition generator
 	 */
-	public CompositionIterator(CompositionGenerator generator) {
+	CompositionIterator(CompositionGenerator generator) {
 		super();
 		_generator = generator;
 
@@ -92,7 +89,7 @@ public class CompositionIterator implements
 	/**
 	 * Returns current composition
 	 */
-	protected ICombinatoricsVector<Integer> getCurrentItem() {
+	private ICombinatoricsVector<Integer> getCurrentItem() {
 
 		_currentComposition = Factory.<Integer> createVector();
 

--- a/src/main/java/org/paukov/combinatorics/composition/IntegerCompositionIterator.java
+++ b/src/main/java/org/paukov/combinatorics/composition/IntegerCompositionIterator.java
@@ -18,44 +18,44 @@ import org.paukov.combinatorics.IntegerVector;
  * @see IntegerCompositionGenerator
  * @version 2.0
  */
-public class IntegerCompositionIterator implements Iterator<IntegerVector> {
+class IntegerCompositionIterator implements Iterator<IntegerVector> {
 
 	/**
 	 * Generator
 	 */
-	protected final IntegerCompositionGenerator _generator;
+	final IntegerCompositionGenerator _generator;
 
 	/**
 	 * Current composition
 	 */
-	protected IntegerVector _currentComposition = null;
+	IntegerVector _currentComposition = null;
 
 	/**
 	 * Current index of the weak composition
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Subset generator
 	 */
-	protected final IntegerGenerator _subsetGenerator;
+	final IntegerGenerator _subsetGenerator;
 
 	/**
 	 * Subset iterator
 	 */
-	protected final Iterator<IntegerVector> _subsetIterator;
+	final Iterator<IntegerVector> _subsetIterator;
 
 	/**
 	 * Current subset
 	 */
-	protected IntegerVector _currentSubset = null;
+	IntegerVector _currentSubset = null;
 
 	/**
 	 * Constructor of the iterator
 	 * 
 	 * @param generator	The composition generator
 	 */
-	public IntegerCompositionIterator(IntegerCompositionGenerator generator) {
+	IntegerCompositionIterator(IntegerCompositionGenerator generator) {
 		super();
 		_generator = generator;
 
@@ -96,7 +96,7 @@ public class IntegerCompositionIterator implements Iterator<IntegerVector> {
 	/**
 	 * Returns current composition
 	 */
-	protected IntegerVector getCurrentItem() {
+	private IntegerVector getCurrentItem() {
 
 		int[] vector = _currentSubset.getVector();
 		_currentComposition = IntegerFactory

--- a/src/main/java/org/paukov/combinatorics/partition/PartitionIterator.java
+++ b/src/main/java/org/paukov/combinatorics/partition/PartitionIterator.java
@@ -19,23 +19,23 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @see PartitionGenerator
  * @version 2.0
  */
-public class PartitionIterator implements
+class PartitionIterator implements
 		Iterator<ICombinatoricsVector<Integer>> {
 
 	/**
 	 * Generator
 	 */
-	protected final PartitionGenerator _generator;
+	final PartitionGenerator _generator;
 
 	/**
 	 * Current partition
 	 */
-	protected ICombinatoricsVector<Integer> _currentPartition = null;
+	ICombinatoricsVector<Integer> _currentPartition = null;
 
 	/**
 	 * Index of the current partition
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Helper vectors
@@ -54,7 +54,7 @@ public class PartitionIterator implements
 	 * @param generator
 	 *            Generator
 	 */
-	public PartitionIterator(PartitionGenerator generator) {
+	PartitionIterator(PartitionGenerator generator) {
 		_generator = generator;
 		_mVector = new int[generator._initialValue + 2];
 		_zVector = new int[generator._initialValue + 2];
@@ -140,11 +140,11 @@ public class PartitionIterator implements
 		_currentPartition = Factory.createVector(list);
 	}
 
-	private final int getInternalVectorValue(int index, int[] vector) {
+	private int getInternalVectorValue(int index, int[] vector) {
 		return vector[index + 1];
 	}
 
-	private final void setInternalVectorValue(int index, int[] vector, int value) {
+	private void setInternalVectorValue(int index, int[] vector, int value) {
 		vector[index + 1] = value;
 	}
 

--- a/src/main/java/org/paukov/combinatorics/permutations/DuplicatedPermutationIterator.java
+++ b/src/main/java/org/paukov/combinatorics/permutations/DuplicatedPermutationIterator.java
@@ -22,35 +22,35 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of elements in the permutations
  */
-public class DuplicatedPermutationIterator<T> implements
+class DuplicatedPermutationIterator<T> implements
 		Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Generator
 	 */
-	protected final Generator<T> _generator;
+	final Generator<T> _generator;
 
 	/**
 	 * Current permutation
 	 */
-	protected ICombinatoricsVector<T> _currentPermutation;
+	ICombinatoricsVector<T> _currentPermutation;
 
 	/**
 	 * Current index of current permutation
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Number of elements in the permutations
 	 */
-	protected final int _length;
+	final int _length;
 
 	/**
 	 * Internal data
 	 */
 	private int _data[] = null;
 	private boolean _firstIteration = true;
-	protected ICombinatoricsVector<T> _initialOrderedPermutation;
+	ICombinatoricsVector<T> _initialOrderedPermutation;
 
 	/**
 	 * Constructor
@@ -58,7 +58,7 @@ public class DuplicatedPermutationIterator<T> implements
 	 * @param generator
 	 *            Permutation generator
 	 */
-	public DuplicatedPermutationIterator(Generator<T> generator) {
+	DuplicatedPermutationIterator(Generator<T> generator) {
 		_generator = generator;
 		_length = generator.getOriginalVector().getSize();
 		_data = new int[_length];

--- a/src/main/java/org/paukov/combinatorics/permutations/PermutationIterator.java
+++ b/src/main/java/org/paukov/combinatorics/permutations/PermutationIterator.java
@@ -20,27 +20,27 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of elements in the permutations
  */
-public class PermutationIterator<T> implements Iterator<ICombinatoricsVector<T>> {
+class PermutationIterator<T> implements Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Generator
 	 */
-	protected final Generator<T> _generator;
+	final Generator<T> _generator;
 
 	/**
 	 * Current permutation
 	 */
-	protected ICombinatoricsVector<T> _currentPermutation;
+	ICombinatoricsVector<T> _currentPermutation;
 
 	/**
 	 * Current index of current permutation
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Number of elements in the permutations
 	 */
-	protected final int _length;
+	final int _length;
 
 	/**
 	 * Internal data
@@ -60,7 +60,7 @@ public class PermutationIterator<T> implements Iterator<ICombinatoricsVector<T>>
 	 * @param generator
 	 *            Permutation generator
 	 */
-	public PermutationIterator(Generator<T> generator) {
+	PermutationIterator(Generator<T> generator) {
 		_generator = generator;
 		_length = generator.getOriginalVector().getSize();
 		_currentPermutation = Factory.createVector(generator

--- a/src/main/java/org/paukov/combinatorics/permutations/PermutationWithRepetitionIterator.java
+++ b/src/main/java/org/paukov/combinatorics/permutations/PermutationWithRepetitionIterator.java
@@ -22,33 +22,33 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of the elements in the permutations
  */
-public class PermutationWithRepetitionIterator<T extends Object> implements
+class PermutationWithRepetitionIterator<T extends Object> implements
 		Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Generator
 	 */
-	protected final PermutationWithRepetitionGenerator<T> _generator;
+	final PermutationWithRepetitionGenerator<T> _generator;
 
 	/**
 	 * Current permutation
 	 */
-	protected ICombinatoricsVector<T> _currentPermutation = null;
+	ICombinatoricsVector<T> _currentPermutation = null;
 
 	/**
 	 * Index of the current permutation
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Number of elements in the core vector
 	 */
-	protected final int _n;
+	final int _n;
 
 	/**
 	 * Number of elements in the generated permutations
 	 */
-	protected final int _k;
+	final int _k;
 
 	/**
 	 * Internal data
@@ -61,7 +61,7 @@ public class PermutationWithRepetitionIterator<T extends Object> implements
 	 * @param generator
 	 *            Generator
 	 */
-	public PermutationWithRepetitionIterator(
+	PermutationWithRepetitionIterator(
 			PermutationWithRepetitionGenerator<T> generator) {
 		_generator = generator;
 		_n = generator.getOriginalVector().getSize();

--- a/src/main/java/org/paukov/combinatorics/subsets/IntegerSubListIterator.java
+++ b/src/main/java/org/paukov/combinatorics/subsets/IntegerSubListIterator.java
@@ -20,37 +20,37 @@ import org.paukov.combinatorics.IntegerVector;
  * @see IntegerSubSetGenerator
  * 
  */
-public class IntegerSubListIterator implements Iterator<IntegerVector> {
+class IntegerSubListIterator implements Iterator<IntegerVector> {
 
 	/**
 	 * Subset generator
 	 */
-	protected final IntegerGenerator _generator;
+	final IntegerGenerator _generator;
 
 	/**
 	 * Current sublist
 	 */
-	protected IntegerVector _currentSubList = null;
+	IntegerVector _currentSubList = null;
 
 	/**
 	 * Index of the current sub-list
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Sub set iterator
 	 */
-	protected final IntegerSubSetIterator _subSetsIterator;
+	final IntegerSubSetIterator _subSetsIterator;
 
 	/**
 	 * Set of the result vectors (with duplicates)
 	 */
-	protected final Set<IntegerVector> _result = new LinkedHashSet<IntegerVector>();
+	final Set<IntegerVector> _result = new LinkedHashSet<IntegerVector>();
 
 	/**
 	 * Iterator over the result vectors
 	 */
-	protected Iterator<IntegerVector> _resultIterator = null;
+	Iterator<IntegerVector> _resultIterator = null;
 
 	/**
 	 * Constructor
@@ -58,7 +58,7 @@ public class IntegerSubListIterator implements Iterator<IntegerVector> {
 	 * @param generator
 	 *            The subset generator
 	 */
-	public IntegerSubListIterator(IntegerGenerator generator) {
+	IntegerSubListIterator(IntegerGenerator generator) {
 		_generator = generator;
 		_subSetsIterator = new IntegerSubSetIterator(generator);
 		init();

--- a/src/main/java/org/paukov/combinatorics/subsets/IntegerSubSetIterator.java
+++ b/src/main/java/org/paukov/combinatorics/subsets/IntegerSubSetIterator.java
@@ -19,27 +19,27 @@ import org.paukov.combinatorics.IntegerVector;
  * @see IntegerSubSetGenerator
  * 
  */
-public class IntegerSubSetIterator implements Iterator<IntegerVector> {
+class IntegerSubSetIterator implements Iterator<IntegerVector> {
 
 	/**
 	 * Subset generator
 	 */
-	protected final IntegerGenerator _generator;
+	final IntegerGenerator _generator;
 
 	/**
 	 * Current subset
 	 */
-	protected IntegerVector _currentSubSet = null;
+	IntegerVector _currentSubSet = null;
 
 	/**
 	 * Index of the current subset
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Size of the subset
 	 */
-	protected final int _length;
+	final int _length;
 
 	/**
 	 * internal bit vector, representing the subset
@@ -52,7 +52,7 @@ public class IntegerSubSetIterator implements Iterator<IntegerVector> {
 	 * @param generator
 	 *            The subset generator
 	 */
-	public IntegerSubSetIterator(IntegerGenerator generator) {
+	IntegerSubSetIterator(IntegerGenerator generator) {
 		_generator = generator;
 		_length = generator.getOriginalVector().getSize();
 		_currentSubSet = IntegerFactory.createIntegerVector(0);

--- a/src/main/java/org/paukov/combinatorics/subsets/SubListIterator.java
+++ b/src/main/java/org/paukov/combinatorics/subsets/SubListIterator.java
@@ -22,37 +22,37 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of the elements in the lists
  */
-public class SubListIterator<T> implements Iterator<ICombinatoricsVector<T>> {
+class SubListIterator<T> implements Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Subset generator
 	 */
-	protected final Generator<T> _generator;
+	final Generator<T> _generator;
 
 	/**
 	 * Current sublist
 	 */
-	protected ICombinatoricsVector<T> _currentSubList = null;
+	ICombinatoricsVector<T> _currentSubList = null;
 
 	/**
 	 * Index of the current sub-list
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Sub set iterator
 	 */
-	protected final SubSetIterator<T> _subSetsIterator;
+	final SubSetIterator<T> _subSetsIterator;
 
 	/**
 	 * Set of the result vectors (with duplicates)
 	 */
-	protected final Set<ICombinatoricsVector<T>> _result = new LinkedHashSet<ICombinatoricsVector<T>>();
+	final Set<ICombinatoricsVector<T>> _result = new LinkedHashSet<ICombinatoricsVector<T>>();
 
 	/**
 	 * Iterator over the result vectors
 	 */
-	protected Iterator<ICombinatoricsVector<T>> _resultIterator = null;
+	Iterator<ICombinatoricsVector<T>> _resultIterator = null;
 
 	/**
 	 * Constructor
@@ -60,7 +60,7 @@ public class SubListIterator<T> implements Iterator<ICombinatoricsVector<T>> {
 	 * @param generator
 	 *            The subset generator
 	 */
-	public SubListIterator(Generator<T> generator) {
+	SubListIterator(Generator<T> generator) {
 		_generator = generator;
 		_subSetsIterator = new SubSetIterator<T>(generator);
 		init();

--- a/src/main/java/org/paukov/combinatorics/subsets/SubSetIterator.java
+++ b/src/main/java/org/paukov/combinatorics/subsets/SubSetIterator.java
@@ -21,27 +21,27 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @param <T>
  *            Type of the elements of the subsets
  */
-public class SubSetIterator<T> implements Iterator<ICombinatoricsVector<T>> {
+class SubSetIterator<T> implements Iterator<ICombinatoricsVector<T>> {
 
 	/**
 	 * Subset generator
 	 */
-	protected final Generator<T> _generator;
+	final Generator<T> _generator;
 
 	/**
 	 * Current subset
 	 */
-	protected ICombinatoricsVector<T> _currentSubSet = null;
+	ICombinatoricsVector<T> _currentSubSet = null;
 
 	/**
 	 * Index of the current subset
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * Size of the subset
 	 */
-	protected final int _length;
+	final int _length;
 
 	/**
 	 * internal bit vector, representing the subset
@@ -54,7 +54,7 @@ public class SubSetIterator<T> implements Iterator<ICombinatoricsVector<T>> {
 	 * @param generator
 	 *            The subset generator
 	 */
-	public SubSetIterator(Generator<T> generator) {
+	SubSetIterator(Generator<T> generator) {
 		_generator = generator;
 		_length = generator.getOriginalVector().getSize();
 		_currentSubSet = Factory.<T>createVector();

--- a/src/main/java/org/paukov/combinatorics/util/ComplexCombinationIterator.java
+++ b/src/main/java/org/paukov/combinatorics/util/ComplexCombinationIterator.java
@@ -21,34 +21,34 @@ import org.paukov.combinatorics.ICombinatoricsVector;
  * @version 2.0
  * @see ComplexCombinationGenerator
  */
-public class ComplexCombinationIterator<T>
+class ComplexCombinationIterator<T>
 		implements
 		Iterator<ICombinatoricsVector<ICombinatoricsVector<T>>> {
 
 	/**
 	 * Generator
 	 */
-	protected final ComplexCombinationGenerator<T> _generator;
+	final ComplexCombinationGenerator<T> _generator;
 
 	/**
 	 * Current combination
 	 */
-	protected ICombinatoricsVector<ICombinatoricsVector<T>> _currentComplexCombination = null;
+	ICombinatoricsVector<ICombinatoricsVector<T>> _currentComplexCombination = null;
 
 	/**
 	 * Current index of the combination
 	 */
-	protected long _currentIndex = 0;
+	long _currentIndex = 0;
 
 	/**
 	 * The set of the generated combinations
 	 */
-	protected Set<ICombinatoricsVector<ICombinatoricsVector<T>>> _resultSet = new LinkedHashSet<ICombinatoricsVector<ICombinatoricsVector<T>>>();
+	Set<ICombinatoricsVector<ICombinatoricsVector<T>>> _resultSet = new LinkedHashSet<ICombinatoricsVector<ICombinatoricsVector<T>>>();
 
 	/**
 	 * The iterator over the result combinations
 	 */
-	protected Iterator<ICombinatoricsVector<ICombinatoricsVector<T>>> _resultIterator = null;
+	Iterator<ICombinatoricsVector<ICombinatoricsVector<T>>> _resultIterator = null;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
This pull request updates all iterator classes accessibility to 'package private', so they are not accessible from outside the library
