### PR TITLE
Fixed exception in CombinatoricsVector. Fixed generation of complex combinations with empty set in ComplexCombinationIterator.

### DIFF
--- a/src/main/java/org/paukov/combinatorics/CombinatoricsVector.java
+++ b/src/main/java/org/paukov/combinatorics/CombinatoricsVector.java
@@ -172,7 +172,7 @@ public class CombinatoricsVector<T> implements ICombinatoricsVector<T> {
 
 		int count = 0;
 		for (T element : _vector) {
-			if (element.equals(value))
+			if (element == value || (element != null && element.equals(value)))
 				count++;
 		}
 		return count;

--- a/src/main/java/org/paukov/combinatorics/util/ComplexCombinationGenerator.java
+++ b/src/main/java/org/paukov/combinatorics/util/ComplexCombinationGenerator.java
@@ -125,7 +125,7 @@ public class ComplexCombinationGenerator<T> extends
 			int combinationsLength, boolean isOrderImportant,
 			boolean excludeEmptySet) {
 
-		if (combinationsLength > originalVector.getSize())
+		if (excludeEmptySet && combinationsLength > originalVector.getSize())
 			throw new RuntimeException(
 					"Unable to generate complex combinations, the requested combination length is more then the size of the original vector, length: "
 							+ combinationsLength


### PR DESCRIPTION
1. Fixed NullPointerException exception in CombinatoricsVector when input Vector has null elements.
2. Allow ComplexCombinationIterator to generate complex combinations when requested combination length is more then the size of the original vector and excludeEmptySet is false.