### PR TITLE
Install OpenJDK 6 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: java
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: java
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 jdk:
   - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
 
 script: mvn cobertura:cobertura coveralls:cobertura


### PR DESCRIPTION
Trusty images on Travis doesn't have OpenJDK 6 installed by default. See travis-ci/travis-ci#8199